### PR TITLE
Ignore attribute codes if they are empty in the Family Xlsx Iterator

### DIFF
--- a/Iterator/FamilyXlsxFileIterator.php
+++ b/Iterator/FamilyXlsxFileIterator.php
@@ -62,6 +62,9 @@ class FamilyXlsxFileIterator extends AbstractXlsxFileIterator
             }
             if ($index >= (int) $this->options['attribute_data_row']) {
                 $code = $row[$codeColumn];
+                if ($code === '') {
+                    continue;
+                }
                 $data['attributes'][] = $code;
                 if (isset($row[$useAsLabelColumn]) && ('1' === trim($row[$useAsLabelColumn]))) {
                     $data['attribute_as_label'] = $code;


### PR DESCRIPTION
We've recently attempted to automatically generate the family sheets with formulas, but every now and then some formulas result in empty attribute code at the end of the sheet. They are not empty in excel, since there is a formula in there, but it results in an empty string.

The family iterator is currently not validating the attribute codes, so this results in `The "Attribute" with code "" is unknown` errors.

Adding this little condition solves the issue.